### PR TITLE
Fix macOS and Windows CI: install netCDF system library

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,5 +13,6 @@
 ^heatwave3\.code-workspace$
 ^configure\.win$
 ^src/Makevars$
+^windows$
 ^CLAUDE\.md$
 ^dev$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install netcdf (macOS)
+        if: runner.os == 'macOS'
+        run: brew install netcdf
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/*.so
 src/*.dll
 src/Makevars
 dev/
+/windows/

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,18 @@
+VERSION = 4.4.1.1-dap
+
 CXX_STD = CXX17
 
-PKG_CPPFLAGS = -I$(LIB_NETCDF)/include
-PKG_LIBS = -L$(LIB_NETCDF)/lib -lnetcdf $(LAPACK_LIBS) $(BLAS_LIBS) $(SHLIB_OPENMP_CXXFLAGS)
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_CPPFLAGS = -I../windows/netcdf-$(VERSION)/include
+PKG_LIBS = -L../windows/netcdf-$(VERSION)/lib$(R_ARCH) \
+	-lnetcdf -lcurl -lhdf5_hl -lhdf5 -lszip -lz \
+	-lws2_32 -lcrypt32 -lwldap32
+
+all: clean winlibs
+
+winlibs:
+	"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/winlibs.R" $(VERSION)
+
+clean:
+	rm -Rf $(SHLIB) $(OBJECTS)
+
+.PHONY: all winlibs clean

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,11 +1,15 @@
-VERSION = 4.4.1.1-dap
+VERSION = 4.9.0
 
 CXX_STD = CXX17
 
+# Modern Rtools (R >= 4.2) targets UCRT exclusively, so link against the
+# rwinlib/netcdf ucrt-x86_64 build specifically -- the plain lib/x64 build
+# is compiled against the legacy MSVCRT runtime (__iob_func / _sys_nerr),
+# which is absent from UCRT and fails to link.
 PKG_CPPFLAGS = -I../windows/netcdf-$(VERSION)/include
-PKG_LIBS = -L../windows/netcdf-$(VERSION)/lib$(R_ARCH) \
-	-lnetcdf -lcurl -lhdf5_hl -lhdf5 -lszip -lz \
-	-lws2_32 -lcrypt32 -lwldap32
+PKG_LIBS = -L../windows/netcdf-$(VERSION)/lib/x64-ucrt \
+	-lnetcdf -lhdf5_hl -lhdf5 -lcurl -lssh2 -lssl -lcrypto -lxml2 -lexpat -lintl -lz \
+	-lws2_32 -lcrypt32 -lwldap32 -ladvapi32 -luser32 -lnormaliz -liconv
 
 all: clean winlibs
 

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,12 @@
+# Downloads a prebuilt netcdf-mingw bundle for Windows builds, from
+# https://github.com/rwinlib/netcdf. Invoked by src/Makevars.win before
+# compilation; mirrors the pattern used by the ncdf4 CRAN package.
+VERSION <- commandArgs(TRUE)
+if (!file.exists(sprintf("../windows/netcdf-%s/include/netcdf.h", VERSION))) {
+  if (getRversion() < "3.3.0") setInternet2()
+  download.file(sprintf("https://github.com/rwinlib/netcdf/archive/v%s.zip", VERSION),
+                "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
Neither the macos-latest nor windows-latest GitHub Actions runners ship netCDF pre-installed, and the workflow never installed it -- only Ubuntu passed, because setup-r-dependencies auto-resolves system requirements via apt on Linux (a feature that has no macOS/Windows equivalent). This left ./configure (macOS) and src/Makevars.win (Windows) unable to find netcdf.h/libnetcdf, failing the build before R CMD check could even run.

- macOS: add a `brew install netcdf` CI step; the existing ./configure already auto-detects it via nc-config/pkg-config/the Homebrew prefix.
- Windows: src/Makevars.win now pulls a prebuilt netcdf-mingw bundle from rwinlib/netcdf via tools/winlibs.R, mirroring the CRAN ncdf4 package's proven approach, replacing the old Makevars.win that silently relied on an undefined LIB_NETCDF env var.